### PR TITLE
Fix error related to anticipated call to set xhr.responseType in Firefox

### DIFF
--- a/demo/worker.js
+++ b/demo/worker.js
@@ -32,8 +32,8 @@ self.onmessage = function (e) {
 
 function getJSON(url, callback) {
     var xhr = new XMLHttpRequest();
-    xhr.responseType = 'json';
     xhr.open('GET', url, true);
+    xhr.responseType = 'json';
     xhr.setRequestHeader('Accept', 'application/json');
     xhr.onload = function () {
         if (xhr.readyState === 4 && xhr.status >= 200 && xhr.status < 300 && xhr.response) {


### PR DESCRIPTION
In Firefox, you get a weird error aka *"InvalidStateError: An attempt was made to use an object that is not, or is no longer, usable"* in the console and the cluster is not shown.

According to https://davidwalsh.name/fix-javascript-errors, it seems it's due to the fact that line `xhr.responseType = 'json';` should be set after an `xhr.open`.
Changing the following in demo/worker.js

    xhr.responseType = 'json';
    xhr.open('GET', url, true);:

with

    xhr.open('GET', url, true);
    xhr.responseType = 'json';

make things work in both Firefox and Chrome.

This PR is the above fix for this case.
