### PR TITLE
Add option for including subPoints for clusters

### DIFF
--- a/test/fixtures/places-z0-0-0.json
+++ b/test/fixtures/places-z0-0-0.json
@@ -8,7 +8,8 @@
       "tags": {
         "cluster": true,
         "point_count": 16,
-        "point_count_abbreviated": 16
+        "point_count_abbreviated": 16,
+        "subPoints": null
       }
     },
     {
@@ -19,7 +20,8 @@
       "tags": {
         "cluster": true,
         "point_count": 18,
-        "point_count_abbreviated": 18
+        "point_count_abbreviated": 18,
+        "subPoints": null
       }
     },
     {
@@ -30,7 +32,8 @@
       "tags": {
         "cluster": true,
         "point_count": 13,
-        "point_count_abbreviated": 13
+        "point_count_abbreviated": 13,
+        "subPoints": null
       }
     },
     {
@@ -41,7 +44,8 @@
       "tags": {
         "cluster": true,
         "point_count": 8,
-        "point_count_abbreviated": 8
+        "point_count_abbreviated": 8,
+        "subPoints": null
       }
     },
     {
@@ -52,7 +56,8 @@
       "tags": {
         "cluster": true,
         "point_count": 15,
-        "point_count_abbreviated": 15
+        "point_count_abbreviated": 15,
+        "subPoints": null
       }
     },
     {
@@ -63,7 +68,8 @@
       "tags": {
         "cluster": true,
         "point_count": 4,
-        "point_count_abbreviated": 4
+        "point_count_abbreviated": 4,
+        "subPoints": null
       }
     },
     {
@@ -74,7 +80,8 @@
       "tags": {
         "cluster": true,
         "point_count": 6,
-        "point_count_abbreviated": 6
+        "point_count_abbreviated": 6,
+        "subPoints": null
       }
     },
     {
@@ -102,7 +109,8 @@
       "tags": {
         "cluster": true,
         "point_count": 3,
-        "point_count_abbreviated": 3
+        "point_count_abbreviated": 3,
+        "subPoints": null
       }
     },
     {
@@ -113,7 +121,8 @@
       "tags": {
         "cluster": true,
         "point_count": 4,
-        "point_count_abbreviated": 4
+        "point_count_abbreviated": 4,
+        "subPoints": null
       }
     },
     {
@@ -124,7 +133,8 @@
       "tags": {
         "cluster": true,
         "point_count": 6,
-        "point_count_abbreviated": 6
+        "point_count_abbreviated": 6,
+        "subPoints": null
       }
     },
     {
@@ -203,7 +213,8 @@
       "tags": {
         "cluster": true,
         "point_count": 3,
-        "point_count_abbreviated": 3
+        "point_count_abbreviated": 3,
+        "subPoints": null
       }
     },
     {
@@ -214,7 +225,8 @@
       "tags": {
         "cluster": true,
         "point_count": 6,
-        "point_count_abbreviated": 6
+        "point_count_abbreviated": 6,
+        "subPoints": null
       }
     },
     {
@@ -259,7 +271,8 @@
       "tags": {
         "cluster": true,
         "point_count": 2,
-        "point_count_abbreviated": 2
+        "point_count_abbreviated": 2,
+        "subPoints": null
       }
     },
     {
@@ -270,7 +283,8 @@
       "tags": {
         "cluster": true,
         "point_count": 13,
-        "point_count_abbreviated": 13
+        "point_count_abbreviated": 13,
+        "subPoints": null
       }
     },
     {
@@ -281,7 +295,8 @@
       "tags": {
         "cluster": true,
         "point_count": 5,
-        "point_count_abbreviated": 5
+        "point_count_abbreviated": 5,
+        "subPoints": null
       }
     },
     {
@@ -292,7 +307,8 @@
       "tags": {
         "cluster": true,
         "point_count": 2,
-        "point_count_abbreviated": 2
+        "point_count_abbreviated": 2,
+        "subPoints": null
       }
     },
     {
@@ -320,7 +336,8 @@
       "tags": {
         "cluster": true,
         "point_count": 13,
-        "point_count_abbreviated": 13
+        "point_count_abbreviated": 13,
+        "subPoints": null
       }
     },
     {
@@ -331,7 +348,8 @@
       "tags": {
         "cluster": true,
         "point_count": 4,
-        "point_count_abbreviated": 4
+        "point_count_abbreviated": 4,
+        "subPoints": null
       }
     },
     {
@@ -359,7 +377,8 @@
       "tags": {
         "cluster": true,
         "point_count": 7,
-        "point_count_abbreviated": 7
+        "point_count_abbreviated": 7,
+        "subPoints": null
       }
     },
     {
@@ -421,7 +440,8 @@
       "tags": {
         "cluster": true,
         "point_count": 2,
-        "point_count_abbreviated": 2
+        "point_count_abbreviated": 2,
+        "subPoints": null
       }
     },
     {
@@ -432,7 +452,8 @@
       "tags": {
         "cluster": true,
         "point_count": 13,
-        "point_count_abbreviated": 13
+        "point_count_abbreviated": 13,
+        "subPoints": null
       }
     },
     {
@@ -443,7 +464,8 @@
       "tags": {
         "cluster": true,
         "point_count": 4,
-        "point_count_abbreviated": 4
+        "point_count_abbreviated": 4,
+        "subPoints": null
       }
     },
     {
@@ -471,7 +493,8 @@
       "tags": {
         "cluster": true,
         "point_count": 7,
-        "point_count_abbreviated": 7
+        "point_count_abbreviated": 7,
+        "subPoints": null
       }
     },
     {
@@ -499,7 +522,8 @@
       "tags": {
         "cluster": true,
         "point_count": 6,
-        "point_count_abbreviated": 6
+        "point_count_abbreviated": 6,
+        "subPoints": null
       }
     },
     {
@@ -510,7 +534,8 @@
       "tags": {
         "cluster": true,
         "point_count": 2,
-        "point_count_abbreviated": 2
+        "point_count_abbreviated": 2,
+        "subPoints": null
       }
     }
   ]

--- a/test/test.js
+++ b/test/test.js
@@ -12,3 +12,14 @@ test(function (t) {
     t.same(tile.features, placesTile.features);
     t.end();
 });
+
+test(function (t) {
+    var index = supercluster({includeSubPoints: true}).load(places.features);
+    var tile = index.getTile(0, 0, 0);
+    tile.features.forEach((feature) => {
+        if (feature.tags.cluster) {
+            t.same(feature.tags.point_count, feature.tags.subPoints.length);
+        }
+    });
+    t.end();
+});


### PR DESCRIPTION
I'm using supercluster with the Mapbox GL JS library. The biggest shortcoming with the supercluster clustering for good UX has been the lack of ability to reliably zoom in to the clusters. Using a fixed zoom bigger than +1 is bound to cause issues, where some of the points/clusters in the original cluster that was clicked are no longer visible. 

This PR adds a includeSubPoints flag, which if turned on, includes all the coordinates of the points belonging to a cluster to the cluster's subPoints property. With the property it is easy then to calculate the proper bounding box for each cluster when they are clicked and visualize the bounds of the cluster similar to [Leaflet.markercluster](https://github.com/Leaflet/Leaflet.markercluster).

I ran some manual tests with my laptop (Macbook Pro 2.5 GHz Intel Core i7, 16 GB RAM with Google Chrome Version 53.0.2785.143 (64-bit). I used the earthquakes.geojson file found in [this example](https://www.mapbox.com/mapbox-gl-js/example/cluster/) with the Leaflet.js example shipped with supercluster. With the includeSubPoints flag on the cluster creation time increased about 20%, from ~50ms to ~60ms. The heap size increased from ~14.5 mb to ~15 mb.
