### PR TITLE
getChildren method for getting children of a cluster on the next zoom

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,9 +64,23 @@ SuperCluster.prototype = {
         var clusters = [];
         for (var i = 0; i < ids.length; i++) {
             var c = tree.points[ids[i]];
-            clusters.push(c.id !== -1 ? this.points[c.id] : getClusterJSON(c));
+            clusters.push(c.numPoints === 1 ? this.points[c.id] : getClusterJSON(c));
         }
         return clusters;
+    },
+
+    getChildren: function (clusterId, zoom) {
+        var origin = this.trees[zoom + 1].points[clusterId];
+        var r = this.options.radius / (this.options.extent * Math.pow(2, zoom));
+        var points = this.trees[zoom + 1].within(origin.x, origin.y, r);
+        var children = [];
+        for (var i = 0; i < points.length; i++) {
+            var c = this.trees[zoom + 1].points[points[i]];
+            if (c.parentId === clusterId) {
+                children.push(c.numPoints === 1 ? this.points[c.id] : getClusterJSON(c));
+            }
+        }
+        return children;
     },
 
     getTile: function (z, x, y) {
@@ -109,7 +123,7 @@ SuperCluster.prototype = {
                     Math.round(this.options.extent * (c.x * z2 - x)),
                     Math.round(this.options.extent * (c.y * z2 - y))
                 ]],
-                tags: c.id !== -1 ? this.points[c.id].properties : getClusterProperties(c)
+                tags: c.numPoints === 1 ? this.points[c.id].properties : getClusterProperties(c)
             });
         }
     },
@@ -133,7 +147,6 @@ SuperCluster.prototype = {
             var tree = this.trees[zoom + 1];
             var neighborIds = tree.within(p.x, p.y, r);
 
-            var foundNeighbors = false;
             var numPoints = p.numPoints;
             var wx = p.x * numPoints;
             var wy = p.y * numPoints;
@@ -142,15 +155,20 @@ SuperCluster.prototype = {
                 var b = tree.points[neighborIds[j]];
                 // filter out neighbors that are too far or already processed
                 if (zoom < b.zoom) {
-                    foundNeighbors = true;
                     b.zoom = zoom; // save the zoom (so it doesn't get processed twice)
                     wx += b.x * b.numPoints; // accumulate coordinates for calculating weighted center
                     wy += b.y * b.numPoints;
                     numPoints += b.numPoints;
+                    b.parentId = i;
                 }
             }
 
-            clusters.push(foundNeighbors ? createCluster(wx / numPoints, wy / numPoints, numPoints, -1) : p);
+            if (numPoints === 1) {
+                clusters.push(p);
+            } else {
+                p.parentId = i;
+                clusters.push(createCluster(wx / numPoints, wy / numPoints, numPoints, i));
+            }
         }
 
         return clusters;
@@ -162,7 +180,12 @@ function createCluster(x, y, numPoints, id) {
         x: x, // weighted cluster center
         y: y,
         zoom: Infinity, // the last zoom the cluster was processed at
-        id: id, // index of the source feature in the original input array
+
+        // point id: index of the source feature in the original input array
+        // cluster id: index of the first child of the cluster in the zoom level tree
+        id: id,
+
+        parentId: -1, // parent cluster id
         numPoints: numPoints
     };
 }
@@ -189,6 +212,7 @@ function getClusterProperties(cluster) {
                  count >= 1000 ? (Math.round(count / 100) / 10) + 'k' : count;
     return {
         cluster: true,
+        cluster_id: cluster.id,
         point_count: count,
         point_count_abbreviated: abbrev
     };

--- a/test/fixtures/places-z0-0-0.json
+++ b/test/fixtures/places-z0-0-0.json
@@ -7,6 +7,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 0,
         "point_count": 16,
         "point_count_abbreviated": 16
       }
@@ -18,6 +19,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 1,
         "point_count": 18,
         "point_count_abbreviated": 18
       }
@@ -29,6 +31,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 2,
         "point_count": 13,
         "point_count_abbreviated": 13
       }
@@ -40,6 +43,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 3,
         "point_count": 8,
         "point_count_abbreviated": 8
       }
@@ -51,6 +55,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 4,
         "point_count": 15,
         "point_count_abbreviated": 15
       }
@@ -62,6 +67,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 5,
         "point_count": 4,
         "point_count_abbreviated": 4
       }
@@ -73,6 +79,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 8,
         "point_count": 6,
         "point_count_abbreviated": 6
       }
@@ -101,6 +108,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 11,
         "point_count": 3,
         "point_count_abbreviated": 3
       }
@@ -112,6 +120,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 13,
         "point_count": 4,
         "point_count_abbreviated": 4
       }
@@ -123,6 +132,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 15,
         "point_count": 6,
         "point_count_abbreviated": 6
       }
@@ -202,6 +212,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 21,
         "point_count": 3,
         "point_count_abbreviated": 3
       }
@@ -213,6 +224,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 23,
         "point_count": 6,
         "point_count_abbreviated": 6
       }
@@ -258,6 +270,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 26,
         "point_count": 2,
         "point_count_abbreviated": 2
       }
@@ -269,6 +282,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 30,
         "point_count": 13,
         "point_count_abbreviated": 13
       }
@@ -280,6 +294,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 32,
         "point_count": 5,
         "point_count_abbreviated": 5
       }
@@ -291,6 +306,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 35,
         "point_count": 2,
         "point_count_abbreviated": 2
       }
@@ -319,6 +335,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 38,
         "point_count": 13,
         "point_count_abbreviated": 13
       }
@@ -330,6 +347,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 40,
         "point_count": 4,
         "point_count_abbreviated": 4
       }
@@ -358,6 +376,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 47,
         "point_count": 7,
         "point_count_abbreviated": 7
       }
@@ -420,6 +439,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 58,
         "point_count": 2,
         "point_count_abbreviated": 2
       }
@@ -431,6 +451,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 38,
         "point_count": 13,
         "point_count_abbreviated": 13
       }
@@ -442,6 +463,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 40,
         "point_count": 4,
         "point_count_abbreviated": 4
       }
@@ -470,6 +492,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 47,
         "point_count": 7,
         "point_count_abbreviated": 7
       }
@@ -498,6 +521,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 23,
         "point_count": 6,
         "point_count_abbreviated": 6
       }
@@ -509,6 +533,7 @@
       ],
       "tags": {
         "cluster": true,
+        "cluster_id": 26,
         "point_count": 2,
         "point_count_abbreviated": 2
       }


### PR DESCRIPTION
Fixes #13. This is a fast approach replacing changes proposed in #27 and #30. Also addresses https://github.com/mapbox/mapbox-gl-js/issues/3318.

It pretty much doesn't affect performance while allowing to accurately fetch "children" clusters, either for spiderfying, generating a hull, precise "zoom to cluster" or any other features.

The way it works is storing the index of the "origin" point the cluster was created from as its id, and also storing `parentId` for each point/cluster that was clustered. Then you can fetch the "origin" point, do a radius query around it on the next zoom and filter out points that are not related to the cluster. This operation is almost instant since it's `O(log N)`.

Let me know what you think!

cc @apkoponen @bewithjonam @stepankuzmin 