### PR TITLE
add getLeaves method for retrieving leaf points (paginated)

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -6,9 +6,34 @@ var supercluster = require('../');
 var places = require('./fixtures/places.json');
 var placesTile = require('./fixtures/places-z0-0-0.json');
 
-test(function (t) {
+test('generates clusters properly', function (t) {
     var index = supercluster().load(places.features);
     var tile = index.getTile(0, 0, 0);
     t.same(tile.features, placesTile.features);
+    t.end();
+});
+
+test('returns children of a cluster', function (t) {
+    var index = supercluster().load(places.features);
+    var childCounts = index.getChildren(0, 0).map((p) => p.properties.point_count || 1);
+    t.same(childCounts, [6, 7, 2, 1]);
+    t.end();
+});
+
+test('returns leaves of a cluster', function (t) {
+    var index = supercluster().load(places.features);
+    var leafNames = index.getLeaves(0, 0, 10, 5).map((p) => p.properties.name);
+    t.same(leafNames, [
+        'Niagara Falls',
+        'Cape San Blas',
+        'Cape Sable',
+        'Cape Canaveral',
+        'San  Salvador',
+        'Cabo Gracias a Dios',
+        'I. de Cozumel',
+        'Grand Cayman',
+        'Miquelon',
+        'Cape Bauld'
+    ]);
     t.end();
 });


### PR DESCRIPTION
Building on #31, this PR adds a method for a super-fast retrieval of leaf points in a cluster with pagination support. This is the second part of solving https://github.com/mapbox/mapbox-gl-js/issues/3318, allowing us to create a UI where you can click on a cluster and get a paginated view of all points in it with ability to jump between pages.

Usage is as follows:

```js
index.getLeaves(
    clusterId, // cluster_id property of the clicked cluster
    zoom,      // zoom of the clicked cluster
    limit,     // how many points to return; 10 by default
    offset);   // how many points to skip for pagination; 0 by default
```

Since this is basically depth-first spatial tree traversal, the call is very fast — e.g. getting 1000 points starting from the 200,000-th from a 400,000-point cluster takes just 2-3ms. Getting an array of all 400k points (`limit = Infinity, offset = 0`) takes 220ms, which is surprisingly fast too.

- [ ] add some tests

cc @apkoponen @bewithjonam @stepankuzmin @popovae