### PR TITLE
Add getClusterExpansionZoom method

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,16 @@ SuperCluster.prototype = {
         return tile.features.length ? tile : null;
     },
 
+    getClusterExpansionZoom: function (clusterId, zoom) {
+        while (zoom < this.options.maxZoom) {
+            var children = this.getChildren(clusterId, zoom);
+            zoom++;
+            if (children.length !== 1) break;
+            clusterId = children[0].properties.cluster_id;
+        }
+        return zoom;
+    },
+
     _appendLeaves: function (result, clusterId, zoom, limit, offset, skipped) {
         var children = this.getChildren(clusterId, zoom);
 

--- a/test/test.js
+++ b/test/test.js
@@ -37,3 +37,13 @@ test('returns leaves of a cluster', function (t) {
     ]);
     t.end();
 });
+
+test('returns cluster expansion zoom', function (t) {
+    var index = supercluster().load(places.features);
+    t.same(index.getClusterExpansionZoom(0, 0), 1);
+    t.same(index.getClusterExpansionZoom(1, 0), 1);
+    t.same(index.getClusterExpansionZoom(11, 0), 2);
+    t.same(index.getClusterExpansionZoom(26, 0), 2);
+    t.same(index.getClusterExpansionZoom(58, 0), 3);
+    t.end();
+});


### PR DESCRIPTION
Closes #6. Given a clusterId (with its zoom), returns the zoom on which this cluster expands into multiple clusters or points. This probably covers what most people need when they ask for "click on cluster to zoom to it", and provides a better experience than "zoom to cluster's bounding box".

cc @hyperknot @itamair