### PR TITLE
Implement map/reduce for custom cluster properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,10 @@ SuperCluster.prototype = {
         reduce: null, // function (accumulated, props) { accumulated.sum += props.sum; }
 
         // initial properties of a cluster (before running the reducer)
-        initial: null, // function () { return {sum: 0}; },
+        initial: function () { return {}; }, // function () { return {sum: 0}; },
 
         // properties to use for individual points when running the reducer
-        map: null // function (props) { return {sum: props.my_value}; },
+        map: function (props) { return props; } // function (props) { return {sum: props.my_value}; },
     },
 
     load: function (points) {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "kdbush": "^1.0.1"
   },
   "devDependencies": {
-    "browserify": "^13.1.1",
-    "eslint": "^3.12.2",
+    "browserify": "^14.0.0",
+    "eslint": "^3.15.0",
     "eslint-config-mourner": "^2.0.1",
     "mkdirp": "^0.5.1",
-    "tap": "^8.0.1",
+    "tap": "^10.0.2",
     "uglifyjs": "^2.4.10"
   },
   "eslintConfig": {

--- a/test/test.js
+++ b/test/test.js
@@ -47,3 +47,15 @@ test('returns cluster expansion zoom', function (t) {
     t.same(index.getClusterExpansionZoom(58, 0), 3);
     t.end();
 });
+
+test('aggregates cluster properties with reduce', function (t) {
+    var index = supercluster({
+        initial: function () { return {sum: 0}; },
+        map: function (props) { return {sum: props.scalerank}; },
+        reduce: function (a, b) { a.sum += b.sum; }
+    }).load(places.features);
+
+    t.equal(index.getTile(0, 0, 0).features[0].tags.sum, 69);
+
+    t.end();
+});


### PR DESCRIPTION
I thought a lot about API design for cluster property aggregations because once we commit to a particular API, it will be difficult to change, and doing support/maintenance for such a complex feature may be a big burden.

In this PR, I'm proposing an alternative implementation to #12 and @redbmk's [fork](https://github.com/redbmk/supercluster), inspired by the [map-reduce concept](https://en.wikipedia.org/wiki/MapReduce). It should hopefully eliminate all the API ambiguity and make writing custom aggregations easier.

- the `initial` function returns the initial properties of a cluster (before accumulation)
- the `map` function specifies how to interpret individual points (as opposed to clusters) when accumulating properties
- the `reduce` function does the accumulation and is similar to `Array` `reduce`.

Here's an example of aggregating point counts per category, an equivalent to [this big 50-line example](https://github.com/redbmk/supercluster/blob/master/demo/aggregator.js) by @lamuertepeluda:

```js
initial: function () {
    return {categories: {}};
},
map: function (properties) {
    var categories = {};
    categories[properties.featureclass || 'uncategorized'] = 1;
    return {categories: categories};
},
reduce: function (accumulated, properties) {
    for (var id in properties.categories) {
        accumulated.categories[id] = (accumulated.categories[id] || 0) + properties.categories[id];
    }
}
```

And here's a slightly bigger example for the `sum`, `min`, `max`, `avg` (equivalent to [this example](https://github.com/redbmk/supercluster/blob/cluster-agg-hash-array/index.js#L24-L35) by @redbmk in the `cluster-agg-hash-array` branch)):

```js
initial: function () {
    return {
        count: 0,
        sum: 0,
        min: Infinity,
        max: -Infinity
    };
},
map: function (properties) {
    return {
        count: 1,
        sum: properties.myValue,
        min: properties.myValue,
        max: properties.myValue
    };
},
reduce: function (accumulated, properties) {
    accumulated.sum += properties.sum;
    accumulated.count += properties.count;
    accumulated.min = Math.min(accumulated.min, properties.min);
    accumulated.max = Math.max(accumulated.max, properties.max);
    accumulated.avg = Math.round(100 * accumulated.sum / accumulated.count) / 100;
}
```

Note that the example above does not rely on internal properties like `numPoints` and if you need a count for the average calculation, you just calculate it manually.

If we add fallbacks for the `map` option (return point properties directly) and the `initial` option (return `{}`), we can also support code similar to @redbmk's examples (with just the `reduce` function), although clear separation of the three concepts makes it much easier to follow what's going on in my opinion.

The performance overhead is acceptable — ~18% both time and memory overhead (compared to current `master`) when providing a reducer, and otherwise zero time overhead and ~10% memory overhead. We might be able to reduce it further too.

I'm keeping the discussion about the Mapbox GL style spec / JS API separate since it shouldn't rely on a specific Supercluster implementation.

@redbmk @lamuertepeluda @johnlaur @cyrilchapon @aparshin @ben657 @georgeke @vibze @ryanbaumann @davecranwell @lucaswoj what do you think?