### PR TITLE
Simplify clusterId-related API methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,9 +149,10 @@ SuperCluster.prototype = {
         return tile.features.length ? tile : null;
     },
 
-    getClusterExpansionZoom: function (clusterId, clusterZoom) {
+    getClusterExpansionZoom: function (clusterId) {
+        var clusterZoom = (clusterId % 32) - 1;
         while (clusterZoom < this.options.maxZoom) {
-            var children = this.getChildren(clusterId, clusterZoom);
+            var children = this.getChildren(clusterId);
             clusterZoom++;
             if (children.length !== 1) break;
             clusterId = children[0].properties.cluster_id;

--- a/test/fixtures/places-z0-0-0.json
+++ b/test/fixtures/places-z0-0-0.json
@@ -7,7 +7,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 0,
+        "cluster_id": 1,
         "point_count": 16,
         "point_count_abbreviated": 16
       }
@@ -19,7 +19,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 1,
+        "cluster_id": 33,
         "point_count": 18,
         "point_count_abbreviated": 18
       }
@@ -31,7 +31,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 2,
+        "cluster_id": 65,
         "point_count": 13,
         "point_count_abbreviated": 13
       }
@@ -43,7 +43,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 3,
+        "cluster_id": 97,
         "point_count": 8,
         "point_count_abbreviated": 8
       }
@@ -55,7 +55,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 4,
+        "cluster_id": 129,
         "point_count": 15,
         "point_count_abbreviated": 15
       }
@@ -67,7 +67,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 5,
+        "cluster_id": 161,
         "point_count": 4,
         "point_count_abbreviated": 4
       }
@@ -79,7 +79,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 8,
+        "cluster_id": 257,
         "point_count": 6,
         "point_count_abbreviated": 6
       }
@@ -108,7 +108,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 11,
+        "cluster_id": 353,
         "point_count": 3,
         "point_count_abbreviated": 3
       }
@@ -120,7 +120,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 13,
+        "cluster_id": 417,
         "point_count": 4,
         "point_count_abbreviated": 4
       }
@@ -132,7 +132,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 15,
+        "cluster_id": 481,
         "point_count": 6,
         "point_count_abbreviated": 6
       }
@@ -212,7 +212,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 21,
+        "cluster_id": 673,
         "point_count": 3,
         "point_count_abbreviated": 3
       }
@@ -224,7 +224,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 23,
+        "cluster_id": 737,
         "point_count": 6,
         "point_count_abbreviated": 6
       }
@@ -270,7 +270,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 26,
+        "cluster_id": 833,
         "point_count": 2,
         "point_count_abbreviated": 2
       }
@@ -282,7 +282,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 30,
+        "cluster_id": 961,
         "point_count": 13,
         "point_count_abbreviated": 13
       }
@@ -294,7 +294,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 32,
+        "cluster_id": 1025,
         "point_count": 5,
         "point_count_abbreviated": 5
       }
@@ -306,7 +306,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 35,
+        "cluster_id": 1121,
         "point_count": 2,
         "point_count_abbreviated": 2
       }
@@ -335,7 +335,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 38,
+        "cluster_id": 1217,
         "point_count": 13,
         "point_count_abbreviated": 13
       }
@@ -347,7 +347,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 40,
+        "cluster_id": 1281,
         "point_count": 4,
         "point_count_abbreviated": 4
       }
@@ -376,7 +376,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 47,
+        "cluster_id": 1505,
         "point_count": 7,
         "point_count_abbreviated": 7
       }
@@ -439,7 +439,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 58,
+        "cluster_id": 1857,
         "point_count": 2,
         "point_count_abbreviated": 2
       }
@@ -451,7 +451,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 38,
+        "cluster_id": 1217,
         "point_count": 13,
         "point_count_abbreviated": 13
       }
@@ -463,7 +463,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 40,
+        "cluster_id": 1281,
         "point_count": 4,
         "point_count_abbreviated": 4
       }
@@ -492,7 +492,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 47,
+        "cluster_id": 1505,
         "point_count": 7,
         "point_count_abbreviated": 7
       }
@@ -521,7 +521,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 23,
+        "cluster_id": 737,
         "point_count": 6,
         "point_count_abbreviated": 6
       }
@@ -533,7 +533,7 @@
       ],
       "tags": {
         "cluster": true,
-        "cluster_id": 26,
+        "cluster_id": 833,
         "point_count": 2,
         "point_count_abbreviated": 2
       }

--- a/test/test.js
+++ b/test/test.js
@@ -15,14 +15,14 @@ test('generates clusters properly', function (t) {
 
 test('returns children of a cluster', function (t) {
     var index = supercluster().load(places.features);
-    var childCounts = index.getChildren(0, 0).map((p) => p.properties.point_count || 1);
+    var childCounts = index.getChildren(1).map((p) => p.properties.point_count || 1);
     t.same(childCounts, [6, 7, 2, 1]);
     t.end();
 });
 
 test('returns leaves of a cluster', function (t) {
     var index = supercluster().load(places.features);
-    var leafNames = index.getLeaves(0, 0, 10, 5).map((p) => p.properties.name);
+    var leafNames = index.getLeaves(1, 10, 5).map((p) => p.properties.name);
     t.same(leafNames, [
         'Niagara Falls',
         'Cape San Blas',
@@ -47,18 +47,18 @@ test('getLeaves handles null-property features', function (t) {
             coordinates: [-79.04411780507252, 43.08771393436908]
         }
     }]));
-    var leaves = index.getLeaves(0, 0, 1, 6);
+    var leaves = index.getLeaves(1, 1, 6);
     t.equal(leaves[0].properties, null);
     t.end();
 });
 
 test('returns cluster expansion zoom', function (t) {
     var index = supercluster().load(places.features);
-    t.same(index.getClusterExpansionZoom(0, 0), 1);
     t.same(index.getClusterExpansionZoom(1, 0), 1);
-    t.same(index.getClusterExpansionZoom(11, 0), 2);
-    t.same(index.getClusterExpansionZoom(26, 0), 2);
-    t.same(index.getClusterExpansionZoom(58, 0), 3);
+    t.same(index.getClusterExpansionZoom(33, 0), 1);
+    t.same(index.getClusterExpansionZoom(353, 0), 2);
+    t.same(index.getClusterExpansionZoom(833, 0), 2);
+    t.same(index.getClusterExpansionZoom(1857, 0), 3);
     t.end();
 });
 


### PR DESCRIPTION
This PR merges `clusterZoom` into `clusterId` so there's just one number to keep track of, simplifying API for `getLeaves`, `getChildren` and `getClusterExpansionZoom` methods, and introducing a descriptive error in case `clusterId` is invalid. 

Closes #43. Since cluster ids will change, this PR is breaking, probably warranting a major release.

cc @almirfilho @myflowpl