### PR TITLE
Support export default (Typescript related)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var kdbush = require('kdbush');
 
 module.exports = supercluster;
+module.exports.default = supercluster;
 
 function supercluster(options) {
     return new SuperCluster(options);


### PR DESCRIPTION
# Support export default (Typescript related)

Mainly used for Typescript support, other bundlers like Rollup/Babel use some other "magic" to support default exports.

Same thing was done for [concaveman](https://github.com/mapbox/concaveman/blob/master/index.js#L9-L10) & polylabel (PR https://github.com/mapbox/polylabel/pull/10):

An update to the Typescript definition has already been made to reflect this change: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/20348

## Rollup "magic" (import default)

```js
import supercluster from 'supercluster'
```

Gets compile to:

```js
'use strict';

function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }

var supercluster = _interopDefault(require('supercluster'));
```

## Rollup "no-magic" (import without default)

```js
import * as supercluster from 'supercluster'
```

Gets compile to:

```js
'use strict';

require('supercluster');
```

CC: @alex3165 @mourner 