### PR TITLE
return maxZoom+1 when the cluster doesn't expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and `offset` is the amount of points to skip (for pagination).
 
 #### `getClusterExpansionZoom(clusterId)`
 
-Returns the zoom on which the cluster expands into several children (useful for "click to zoom" feature) given the cluster's `cluster_id`.
+Returns the zoom on which the cluster expands into several children (useful for "click to zoom" feature) given the cluster's `cluster_id`. If the cluster doesn't expand at `maxZoom`, return `maxZoom + 1`.
 
 ## Options
 

--- a/index.js
+++ b/index.js
@@ -158,7 +158,9 @@ SuperCluster.prototype = {
 
     getClusterExpansionZoom: function (clusterId) {
         var clusterZoom = (clusterId % 32) - 1;
-        while (clusterZoom < this.options.maxZoom) {
+        while (true) {
+            // if we've run out of cluster levels, return next zoom level
+            if (clusterZoom >= this.options.maxZoom) return clusterZoom + 1;
             var children = this.getChildren(clusterId);
             clusterZoom++;
             if (children.length !== 1) break;

--- a/test/test.js
+++ b/test/test.js
@@ -62,6 +62,16 @@ test('returns cluster expansion zoom', function (t) {
     t.end();
 });
 
+test('returns maxZoom+1 when cluster doesn\'t expand', function (t) {
+    var index = supercluster({
+        radius: 60,
+        extent: 256,
+        maxZoom: 17
+    }).load(places.features.concat(places.features));
+    t.same(index.getClusterExpansionZoom(609), 18);
+    t.end();
+});
+
 test('aggregates cluster properties with reduce', function (t) {
     var index = supercluster({
         initial: function () { return {sum: 0}; },


### PR DESCRIPTION
For a map I'm working on, I needed to implement this private copy of getClusterExpansionZoom which differentiates a cluster that expands at maxZoom from one that doesn't expand at all. I think it should be safe to return maxZoom+1 in those cases, and that does expand the cluster for good.