### PR TITLE
Switch to class-based API (idiomatic ES)

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -1,5 +1,5 @@
 
-import supercluster from './index.js';
+import Supercluster from './index.js';
 import v8 from 'v8';
 
 const points = [];
@@ -22,7 +22,7 @@ for (let i = 0; i < 1000000; i++) {
 global.gc();
 const size = v8.getHeapStatistics().used_heap_size;
 
-const index = supercluster({log: true, maxZoom: 6}).load(points);
+const index = new Supercluster({log: true, maxZoom: 6}).load(points);
 
 global.gc();
 console.log(`memory used: ${  Math.round((v8.getHeapStatistics().used_heap_size - size) / 1024)  } KB`);

--- a/demo/worker.js
+++ b/demo/worker.js
@@ -1,4 +1,4 @@
-/*global importScripts supercluster */
+/*global importScripts Supercluster */
 
 importScripts('../dist/supercluster.js');
 
@@ -9,7 +9,7 @@ let index;
 getJSON('../test/fixtures/places.json', (geojson) => {
     console.log(`loaded ${  geojson.length  } points JSON in ${  (Date.now() - now) / 1000  }s`);
 
-    index = supercluster({
+    index = new Supercluster({
         log: true,
         radius: 60,
         extent: 256,

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const defaultOptions = {
     map: props => props // props => ({sum: props.my_value})
 };
 
-class SuperCluster {
+export default class Supercluster {
     constructor(options) {
         this.options = extend(Object.create(defaultOptions), options);
         this.trees = new Array(this.options.maxZoom + 1);
@@ -358,8 +358,4 @@ function getX(p) {
 }
 function getY(p) {
     return p.y;
-}
-
-export default function supercluster(options) {
-    return new SuperCluster(options);
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import buble from 'rollup-plugin-buble';
 const config = (file, plugins) => ({
     input: 'index.js',
     output: {
-        name: 'supercluster',
+        name: 'Supercluster',
         format: 'umd',
         indent: false,
         file

--- a/test/test.js
+++ b/test/test.js
@@ -1,27 +1,27 @@
 
 import tap from 'tap';
-import supercluster from '../index.js';
+import Supercluster from '../index.js';
 
 const test = tap.test;
 const places = require('./fixtures/places.json');
 const placesTile = require('./fixtures/places-z0-0-0.json');
 
 test('generates clusters properly', (t) => {
-    const index = supercluster().load(places.features);
+    const index = new Supercluster().load(places.features);
     const tile = index.getTile(0, 0, 0);
     t.same(tile.features, placesTile.features);
     t.end();
 });
 
 test('returns children of a cluster', (t) => {
-    const index = supercluster().load(places.features);
+    const index = new Supercluster().load(places.features);
     const childCounts = index.getChildren(1).map(p => p.properties.point_count || 1);
     t.same(childCounts, [6, 7, 2, 1]);
     t.end();
 });
 
 test('returns leaves of a cluster', (t) => {
-    const index = supercluster().load(places.features);
+    const index = new Supercluster().load(places.features);
     const leafNames = index.getLeaves(1, 10, 5).map(p => p.properties.name);
     t.same(leafNames, [
         'Niagara Falls',
@@ -39,7 +39,7 @@ test('returns leaves of a cluster', (t) => {
 });
 
 test('getLeaves handles null-property features', (t) => {
-    const index = supercluster().load(places.features.concat([{
+    const index = new Supercluster().load(places.features.concat([{
         type: 'Feature',
         properties: null,
         geometry: {
@@ -53,7 +53,7 @@ test('getLeaves handles null-property features', (t) => {
 });
 
 test('returns cluster expansion zoom', (t) => {
-    const index = supercluster().load(places.features);
+    const index = new Supercluster().load(places.features);
     t.same(index.getClusterExpansionZoom(1), 1);
     t.same(index.getClusterExpansionZoom(33), 1);
     t.same(index.getClusterExpansionZoom(353), 2);
@@ -63,7 +63,7 @@ test('returns cluster expansion zoom', (t) => {
 });
 
 test('aggregates cluster properties with reduce', (t) => {
-    const index = supercluster({
+    const index = new Supercluster({
         initial: () => ({sum: 0}),
         map: props => ({sum: props.scalerank}),
         reduce: (a, b) => { a.sum += b.sum; }
@@ -75,7 +75,7 @@ test('aggregates cluster properties with reduce', (t) => {
 });
 
 test('returns clusters when query crosses international dateline', (t) => {
-    const index = supercluster().load([
+    const index = new Supercluster().load([
         {
             type: 'Feature',
             properties: null,
@@ -118,7 +118,7 @@ test('returns clusters when query crosses international dateline', (t) => {
 });
 
 test('does not crash on weird bbox values', (t) => {
-    const index = supercluster().load(places.features);
+    const index = new Supercluster().load(places.features);
     t.equal(index.getClusters([129.426390, -103.720017, -445.930843, 114.518236], 1).length, 26);
     t.equal(index.getClusters([112.207836, -84.578666, -463.149397, 120.169159], 1).length, 27);
     t.equal(index.getClusters([129.886277, -82.332680, -445.470956, 120.390930], 1).length, 26);


### PR DESCRIPTION
Switches from `supercluster(...)` factory to `new Supercluster(...)` class instantiation, which is more flexible and idiomatic in modern ES, although a breaking change. Will be released in v5.

Closes #99. 