### PR TITLE
Make initial option in map/reduce optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ Returns the zoom on which the cluster expands into several children (useful for 
 
 In addition to the options above, supercluster supports property aggregation with the following three options:
 
-- `initial`: a function that returns an object with cluster's initial properties.
 - `map`: a function that returns properties to use for individual points.
 - `reduce`: a reduce function for calculating properties in clusters.
+- `initial`: an optional function that returns an object with cluster's initial properties;
+  if not provided, reduce will start with mapped values of the first cluster item.
 
 Example of setting up a `sum` cluster property that accumulates the sum of `myValue` property values:
 
 ```js
 var index = new Supercluster({
-    initial: function() { return {sum: 0}; },
     map: function(props) { return {sum: props.myValue}; },
     reduce: function(accumulated, props) { accumulated.sum += props.sum; }
 });

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const defaultOptions = {
     reduce: null, // (accumulated, props) => { accumulated.sum += props.sum; }
 
     // initial properties of a cluster (before running the reducer)
-    initial: () => ({}), // () => ({sum: 0})
+    initial: null, // () => ({sum: 0})
 
     // properties to use for individual points when running the reducer
     map: props => props // props => ({sum: props.my_value})
@@ -238,8 +238,12 @@ export default class Supercluster {
             let clusterProperties = null;
 
             if (reduce) {
-                clusterProperties = initial();
-                this._accumulate(clusterProperties, p);
+                if (initial) {
+                    clusterProperties = initial();
+                    reduce(clusterProperties, this._map(p));
+                } else {
+                    clusterProperties = this._map(p);
+                }
             }
 
             // encode both zoom and point index on which the cluster originated
@@ -259,7 +263,7 @@ export default class Supercluster {
                 b.parentId = id;
 
                 if (reduce) {
-                    this._accumulate(clusterProperties, b);
+                    reduce(clusterProperties, this._map(b));
                 }
             }
 
@@ -274,10 +278,8 @@ export default class Supercluster {
         return clusters;
     }
 
-    _accumulate(clusterProperties, point) {
-        const {map, reduce} = this.options;
-        const properties = point.numPoints ? point.properties : map(this.points[point.index].properties);
-        reduce(clusterProperties, properties);
+    _map(point) {
+        return point.numPoints ? point.properties : this.options.map(this.points[point.index].properties);
     }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -75,6 +75,17 @@ test('returns cluster expansion zoom for maxZoom', (t) => {
 
 test('aggregates cluster properties with reduce', (t) => {
     const index = new Supercluster({
+        map: props => ({sum: props.scalerank}),
+        reduce: (a, b) => { a.sum += b.sum; }
+    }).load(places.features);
+
+    t.equal(index.getTile(0, 0, 0).features[0].tags.sum, 69);
+
+    t.end();
+});
+
+test('aggregates cluster properties with initial provided', (t) => {
+    const index = new Supercluster({
         initial: () => ({sum: 0}),
         map: props => ({sum: props.scalerank}),
         reduce: (a, b) => { a.sum += b.sum; }


### PR DESCRIPTION
This makes `map`/`reduce` more convenient to use by making it possible to omit the `initial` function in most cases.

When `initial` is omitted, the reducer will use the mapped values of the first reduced item as the initial value. So trivial cases like `+`, `min` and `max` will work seamlessly without the need for `initial`.

It's kind of breaking, but I doubt many people depended on `initial` returning `{}` by default, so maybe it's OK to release this as a minor semver update.

cc @redbmk 