### PR TITLE
Remove redundant initial option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A very fast JavaScript library for geospatial point clustering for browsers and 
 ```
 
 ```js
-var index = new Supercluster({
+const index = new Supercluster({
     radius: 40,
     maxZoom: 16
 });
@@ -80,17 +80,15 @@ Returns the zoom on which the cluster expands into several children (useful for 
 
 In addition to the options above, supercluster supports property aggregation with the following three options:
 
-- `map`: a function that returns properties to use for individual points.
-- `reduce`: a reduce function for calculating properties in clusters.
-- `initial`: an optional function that returns an object with cluster's initial properties;
-  if not provided, reduce will start with mapped values of the first cluster item.
+- `map`: a function that returns cluster properties corresponding to a single point.
+- `reduce`: a reduce function that merges properties of two clusters into one.
 
 Example of setting up a `sum` cluster property that accumulates the sum of `myValue` property values:
 
 ```js
-var index = new Supercluster({
-    map: function(props) { return {sum: props.myValue}; },
-    reduce: function(accumulated, props) { accumulated.sum += props.sum; }
+const index = new Supercluster({
+    map: (props) => ({sum: props.myValue}),
+    reduce: (accumulated, props) => { accumulated.sum += props.sum; }
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -12,9 +12,6 @@ const defaultOptions = {
     // a reduce function for calculating custom cluster properties
     reduce: null, // (accumulated, props) => { accumulated.sum += props.sum; }
 
-    // initial properties of a cluster (before running the reducer)
-    initial: null, // () => ({sum: 0})
-
     // properties to use for individual points when running the reducer
     map: props => props // props => ({sum: props.my_value})
 };
@@ -217,7 +214,7 @@ export default class Supercluster {
 
     _cluster(points, zoom) {
         const clusters = [];
-        const {radius, extent, reduce, initial} = this.options;
+        const {radius, extent, reduce} = this.options;
         const r = radius / (extent * Math.pow(2, zoom));
 
         // loop through each point
@@ -235,16 +232,7 @@ export default class Supercluster {
             let wx = p.x * numPoints;
             let wy = p.y * numPoints;
 
-            let clusterProperties = null;
-
-            if (reduce) {
-                if (initial) {
-                    clusterProperties = initial();
-                    reduce(clusterProperties, this._map(p));
-                } else {
-                    clusterProperties = this._map(p);
-                }
-            }
+            const clusterProperties = reduce ? this._map(p) : null;
 
             // encode both zoom and point index on which the cluster originated
             const id = (i << 5) + (zoom + 1);

--- a/test/test.js
+++ b/test/test.js
@@ -84,18 +84,6 @@ test('aggregates cluster properties with reduce', (t) => {
     t.end();
 });
 
-test('aggregates cluster properties with initial provided', (t) => {
-    const index = new Supercluster({
-        initial: () => ({sum: 0}),
-        map: props => ({sum: props.scalerank}),
-        reduce: (a, b) => { a.sum += b.sum; }
-    }).load(places.features);
-
-    t.equal(index.getTile(0, 0, 0).features[0].tags.sum, 69);
-
-    t.end();
-});
-
 test('returns clusters when query crosses international dateline', (t) => {
     const index = new Supercluster().load([
         {


### PR DESCRIPTION
Removes the `initial` option completely, because we can do without it. See discussion in #114 for context. This is a breaking change, so will need a semver major bump. cc @redbmk