### PR TITLE
Fix a regression with cluster aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ const index = new Supercluster({
 });
 ```
 
+Note that `map` must return a new object (not a reference to original properties), and `reduce` must not mutate the second argument (`props`).
+
 ## Developing Supercluster
 
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const index = new Supercluster({
 });
 ```
 
-Note that `map` must return a new object (not a reference to original properties), and `reduce` must not mutate the second argument (`props`).
+Note that `reduce` must not mutate the second argument (`props`).
 
 ## Developing Supercluster
 

--- a/index.js
+++ b/index.js
@@ -13,20 +13,13 @@ const defaultOptions = {
     reduce: null, // (accumulated, props) => { accumulated.sum += props.sum; }
 
     // properties to use for individual points when running the reducer
-    map: props => extend({}, props) // props => ({sum: props.my_value})
+    map: props => props // props => ({sum: props.my_value})
 };
 
 export default class Supercluster {
     constructor(options) {
         this.options = extend(Object.create(defaultOptions), options);
         this.trees = new Array(this.options.maxZoom + 1);
-
-        if (this.options.map) {
-            const props = {};
-            if (props === this.options.map(props)) {
-                throw new Error('Map function must return a new object.');
-            }
-        }
     }
 
     load(points) {
@@ -277,7 +270,9 @@ export default class Supercluster {
         if (point.numPoints) {
             return clone ? extend({}, point.properties) : point.properties;
         }
-        return this.options.map(this.points[point.index].properties);
+        const original = this.points[point.index].properties;
+        const result = this.options.map(original);
+        return clone && result === original ? extend({}, result) : result;
     }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -76,10 +76,14 @@ test('returns cluster expansion zoom for maxZoom', (t) => {
 test('aggregates cluster properties with reduce', (t) => {
     const index = new Supercluster({
         map: props => ({sum: props.scalerank}),
-        reduce: (a, b) => { a.sum += b.sum; }
+        reduce: (a, b) => { a.sum += b.sum; },
+        radius: 100
     }).load(places.features);
 
-    t.equal(index.getTile(0, 0, 0).features[0].tags.sum, 69);
+    t.same(index.getTile(1, 0, 0).features.map(f => f.tags.sum).filter(Boolean),
+        [146, 84, 63, 23, 34, 12, 19, 29, 8, 8, 80, 35]);
+    t.same(index.getTile(0, 0, 0).features.map(f => f.tags.sum).filter(Boolean),
+        [298, 122, 12, 36, 98, 7, 24, 8, 125, 98, 125, 12, 36, 8]);
 
     t.end();
 });


### PR DESCRIPTION
#114 introduced a bug in cluster aggregation where a shared reference to the same properties object from multiple clusters could lead to buggy behavior. This PR fixes the issue and adds additional safeguards for `map` against it.