### PR TITLE
Varying initial weights for points

### DIFF
--- a/demo/worker.js
+++ b/demo/worker.js
@@ -9,6 +9,7 @@ let index;
 getJSON('../test/fixtures/places.json', (geojson) => {
     console.log(`loaded ${  geojson.length  } points JSON in ${  (Date.now() - now) / 1000  }s`);
 
+    geojson.features.forEach((d) => { d.properties.weight = Math.random() * 1000; });
     index = new Supercluster({
         log: true,
         radius: 60,


### PR DESCRIPTION
Supercluster assumes that all the input points are of the same weight 1. There are cases though in which it is desirable to assign varying initial weights to them. E.g. [in this case](https://twitter.com/ilyabo/status/1110673286332076032) the points have masses calculated as the sums of the magnitudes of their incoming/outgoing flows. Larger locations (e.g. Sydney) should have more inertia so that they are not moved too far when clustered with smaller ones. The PR addresses this by adding support for an optional `weight` property in the input points. 