### PR TITLE
Avoid redundant map calls on reduce

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ export default class Supercluster {
             let wx = p.x * numPoints;
             let wy = p.y * numPoints;
 
-            const clusterProperties = reduce ? this._map(p, true) : null;
+            let clusterProperties = reduce && numPoints > 1 ? this._map(p, true) : null;
 
             // encode both zoom and point index on which the cluster originated
             const id = (i << 5) + (zoom + 1);
@@ -251,6 +251,7 @@ export default class Supercluster {
                 b.parentId = id;
 
                 if (reduce) {
+                    if (!clusterProperties) clusterProperties = this._map(p, true);
                     reduce(clusterProperties, this._map(b));
                 }
             }


### PR DESCRIPTION
Closes #130. With this change, when `reduce` is set, `map` will only be called once per original point, rather per unclustered point per zoom. This improves performance of `map`/`reduce` slightly, but not significantly since `map` isn't a bottleneck in JS (although it might be with more complex `map` functions). cc @zmiao 