### PR TITLE
chore(package.json): only deploy transpiled js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "prepublishOnly": "npm run test && npm run build"
   },
   "files": [
-    "index.js",
-    "dist/supercluster.js",
-    "dist/supercluster.min.js"
+    "dist"
   ],
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,6 @@ const config = (file, plugins) => ({
 const bubleConfig = {transforms: {dangerousForOf: true}};
 
 export default [
-    config('dist/supercluster.js', [resolve(), buble(bubleConfig)]),
-    config('dist/supercluster.min.js', [resolve(), terser(), buble(bubleConfig)])
+    config('dist/index.js', [resolve(), buble(bubleConfig)]),
+    config('dist/index.min.js', [resolve(), terser(), buble(bubleConfig)])
 ];


### PR DESCRIPTION
`
import sc from 'superCluster' 
// non-transpiled index.js was used
`
Without deploying index.js, node.js will use transpiled "dist/index" instead.