### PR TITLE
Fix small-radius clusters not always forming on higher zooms

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ const defaultOptions = {
     map: props => props // props => ({sum: props.my_value})
 };
 
+const fround = Math.fround || (tmp => (x => (tmp[0] = +x)))(new Float32Array(1));
+
 export default class Supercluster {
     constructor(options) {
         this.options = extend(Object.create(defaultOptions), options);
@@ -323,8 +325,8 @@ export default class Supercluster {
 
 function createCluster(x, y, id, numPoints, properties) {
     return {
-        x, // weighted cluster center
-        y,
+        x: fround(x), // weighted cluster center; round for consistency with Float32Array index
+        y: fround(y),
         zoom: Infinity, // the last zoom the cluster was processed at
         id, // encodes index of the first child of the cluster and its zoom level
         parentId: -1, // parent cluster id
@@ -336,8 +338,8 @@ function createCluster(x, y, id, numPoints, properties) {
 function createPointCluster(p, id) {
     const [x, y] = p.geometry.coordinates;
     return {
-        x: lngX(x), // projected point coordinates
-        y: latY(y),
+        x: fround(lngX(x)), // projected point coordinates
+        y: fround(latY(y)),
         zoom: Infinity, // the last zoom the point was processed at
         index: id, // index of the source feature in the original input array,
         parentId: -1 // parent cluster id

--- a/test/test.js
+++ b/test/test.js
@@ -157,3 +157,18 @@ test('does not crash on weird bbox values', (t) => {
     t.end();
 });
 
+test('makes sure same-location points are clustered', (t) => {
+    const index = new Supercluster({
+        maxZoom: 20,
+        extent: 8192,
+        radius: 16,
+        log: true
+    }).load([
+        {type: 'Feature', geometry: {type: 'Point', coordinates: [-1.426798, 53.943034]}},
+        {type: 'Feature', geometry: {type: 'Point', coordinates: [-1.426798, 53.943034]}}
+    ]);
+
+    t.equal(index.trees[20].ids.length, 1);
+
+    t.end();
+});


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/2898. Turned out to be a very tricky bug!

Basically, if you set a small cluster radius, same-location points would sometimes fail to cluster on higher zooms, because the point KD-tree index for querying uses `Float32Array` internally for smaller memory footprint, and that's generally enough precision for location data, except in case where we do small radius queries — in this case the query point was float64, while stored coordinates were float32, leading to the query returning zero results.

The fix is to round the internal stored coordinates to float32 outside the index as well, so that the values are consistent. `Math.fround` is the fast way to do that, but I'm still including a fallback for IE11 so that non-GL-JS consumers could benefit from the fix.

Doesn't need C++ port because supercluster.hpp uses double precision for the index.