### PR TITLE
Fix unclustered points snapping to a f32 grid

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,13 +199,26 @@ export default class Supercluster {
         for (const i of ids) {
             const c = points[i];
             const isCluster = c.numPoints;
+
+            let tags, px, py;
+            if (isCluster) {
+                tags = getClusterProperties(c);
+                px = c.x;
+                py = c.y;
+            } else {
+                const p = this.points[c.index];
+                tags = p.properties;
+                px = lngX(p.geometry.coordinates[0]);
+                py = latY(p.geometry.coordinates[1]);
+            }
+
             const f = {
                 type: 1,
                 geometry: [[
-                    Math.round(this.options.extent * (c.x * z2 - x)),
-                    Math.round(this.options.extent * (c.y * z2 - y))
+                    Math.round(this.options.extent * (px * z2 - x)),
+                    Math.round(this.options.extent * (py * z2 - y))
                 ]],
-                tags: isCluster ? getClusterProperties(c) : this.points[c.index].properties
+                tags
             };
 
             // assign id

--- a/test/test.js
+++ b/test/test.js
@@ -172,3 +172,13 @@ test('makes sure same-location points are clustered', (t) => {
 
     t.end();
 });
+
+test('makes sure unclustered point coords are not rounded', (t) => {
+    const index = new Supercluster({maxZoom: 19}).load([
+        {type: 'Feature', geometry: {type: 'Point', coordinates: [173.19150559062456, -41.340357424709275]}}
+    ]);
+
+    t.same(index.getTile(20, 1028744, 656754).features[0].geometry[0], [421, 281]);
+
+    t.end();
+});


### PR DESCRIPTION
Addresses https://github.com/mapbox/mapbox-gl-js/issues/10422 by recovering the original coordinate precision when returning unclustered point features in tiles instead of using the float32-rounded values used for indexing.