### PR TITLE
Avoid creating new objects for same clusters across zooms

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,8 @@ export default class Supercluster {
                 if (b.zoom > zoom) numPoints += b.numPoints || 1;
             }
 
-            if (numPoints >= minPoints) { // enough points to form a cluster
+            // if there were neighbors to merge, and there are enough points to form a cluster
+            if (numPoints > numPointsOrigin && numPoints >= minPoints) {
                 let wx = p.x * numPointsOrigin;
                 let wy = p.y * numPointsOrigin;
 

--- a/test/fixtures/places-z0-0-0.json
+++ b/test/fixtures/places-z0-0-0.json
@@ -2,100 +2,84 @@
   "features": [
     {
       "type": 1,
-      "id": 164,
-      "geometry": [
-        [150, 205]
-      ],
+      "geometry": [[150, 205]],
       "tags": {
         "cluster": true,
         "cluster_id": 164,
         "point_count": 16,
         "point_count_abbreviated": 16
-      }
+      },
+      "id": 164
     },
     {
       "type": 1,
-      "id": 196,
-      "geometry": [
-        [165, 240]
-      ],
+      "geometry": [[165, 240]],
       "tags": {
         "cluster": true,
         "cluster_id": 196,
         "point_count": 18,
         "point_count_abbreviated": 18
-      }
+      },
+      "id": 196
     },
     {
       "type": 1,
-      "id": 228,
-      "geometry": [
-        [179, 303]
-      ],
+      "geometry": [[179, 303]],
       "tags": {
         "cluster": true,
         "cluster_id": 228,
         "point_count": 13,
         "point_count_abbreviated": 13
-      }
+      },
+      "id": 228
     },
     {
       "type": 1,
-      "id": 260,
-      "geometry": [
-        [336, 234]
-      ],
+      "geometry": [[336, 234]],
       "tags": {
         "cluster": true,
         "cluster_id": 260,
         "point_count": 8,
         "point_count_abbreviated": 8
-      }
+      },
+      "id": 260
     },
     {
       "type": 1,
-      "id": 292,
-      "geometry": [
-        [299, 285]
-      ],
+      "geometry": [[299, 285]],
       "tags": {
         "cluster": true,
         "cluster_id": 292,
         "point_count": 15,
         "point_count_abbreviated": 15
-      }
+      },
+      "id": 292
     },
     {
       "type": 1,
-      "id": 324,
-      "geometry": [
-        [71, 419]
-      ],
+      "geometry": [[71, 419]],
       "tags": {
         "cluster": true,
         "cluster_id": 324,
         "point_count": 4,
         "point_count_abbreviated": 4
-      }
+      },
+      "id": 324
     },
     {
       "type": 1,
-      "id": 420,
-      "geometry": [
-        [92, 212]
-      ],
+      "geometry": [[92, 212]],
       "tags": {
         "cluster": true,
         "cluster_id": 420,
         "point_count": 6,
         "point_count_abbreviated": 6
-      }
+      },
+      "id": 420
     },
     {
       "type": 1,
-      "geometry": [
-        [123, 152]
-      ],
+      "geometry": [[123, 152]],
       "tags": {
         "scalerank": 3,
         "name": "Cape Churchill",
@@ -110,48 +94,40 @@
     },
     {
       "type": 1,
-      "id": 516,
-      "geometry": [
-        [162, 345]
-      ],
+      "geometry": [[162, 345]],
       "tags": {
         "cluster": true,
-        "cluster_id": 516,
+        "cluster_id": 581,
         "point_count": 3,
         "point_count_abbreviated": 3
-      }
+      },
+      "id": 581
     },
     {
       "type": 1,
-      "id": 580,
-      "geometry": [
-        [236, 232]
-      ],
+      "geometry": [[236, 232]],
       "tags": {
         "cluster": true,
         "cluster_id": 580,
         "point_count": 4,
         "point_count_abbreviated": 4
-      }
+      },
+      "id": 580
     },
     {
       "type": 1,
-      "id": 644,
-      "geometry": [
-        [259, 193]
-      ],
+      "geometry": [[259, 193]],
       "tags": {
         "cluster": true,
         "cluster_id": 644,
         "point_count": 6,
         "point_count_abbreviated": 6
-      }
+      },
+      "id": 644
     },
     {
       "type": 1,
-      "geometry": [
-        [80, 336]
-      ],
+      "geometry": [[80, 336]],
       "tags": {
         "scalerank": 3,
         "name": "Oceanic pole of inaccessibility",
@@ -166,9 +142,7 @@
     },
     {
       "type": 1,
-      "geometry": [
-        [452, 377]
-      ],
+      "geometry": [[452, 377]],
       "tags": {
         "scalerank": 3,
         "name": "South Magnetic Pole 2005 (est)",
@@ -183,9 +157,7 @@
     },
     {
       "type": 1,
-      "geometry": [
-        [93, 32]
-      ],
+      "geometry": [[93, 32]],
       "tags": {
         "scalerank": 3,
         "name": "North Magnetic Pole 2005 (est)",
@@ -200,9 +172,7 @@
     },
     {
       "type": 1,
-      "geometry": [
-        [159, 84]
-      ],
+      "geometry": [[159, 84]],
       "tags": {
         "scalerank": 4,
         "name": "Cape York",
@@ -217,35 +187,29 @@
     },
     {
       "type": 1,
-      "id": 836,
-      "geometry": [
-        [220, 147]
-      ],
+      "geometry": [[220, 147]],
       "tags": {
         "cluster": true,
         "cluster_id": 836,
         "point_count": 3,
         "point_count_abbreviated": 3
-      }
+      },
+      "id": 836
     },
     {
       "type": 1,
-      "id": 900,
-      "geometry": [
-        [27, 270]
-      ],
+      "geometry": [[27, 270]],
       "tags": {
         "cluster": true,
         "cluster_id": 900,
         "point_count": 6,
         "point_count_abbreviated": 6
-      }
+      },
+      "id": 900
     },
     {
       "type": 1,
-      "geometry": [
-        [100, 296]
-      ],
+      "geometry": [[100, 296]],
       "tags": {
         "scalerank": 4,
         "name": "I. de Pascua",
@@ -260,9 +224,7 @@
     },
     {
       "type": 1,
-      "geometry": [
-        [401, 226]
-      ],
+      "geometry": [[401, 226]],
       "tags": {
         "scalerank": 4,
         "name": "Plain of Jars",
@@ -277,61 +239,51 @@
     },
     {
       "type": 1,
-      "id": 996,
-      "geometry": [
-        [26, 115]
-      ],
+      "geometry": [[26, 115]],
       "tags": {
         "cluster": true,
-        "cluster_id": 996,
+        "cluster_id": 1157,
         "point_count": 2,
         "point_count_abbreviated": 2
-      }
+      },
+      "id": 1157
     },
     {
       "type": 1,
-      "id": 1124,
-      "geometry": [
-        [449, 304]
-      ],
+      "geometry": [[449, 304]],
       "tags": {
         "cluster": true,
         "cluster_id": 1124,
         "point_count": 13,
         "point_count_abbreviated": 13
-      }
+      },
+      "id": 1124
     },
     {
       "type": 1,
-      "id": 1188,
-      "geometry": [
-        [455, 272]
-      ],
+      "geometry": [[455, 272]],
       "tags": {
         "cluster": true,
         "cluster_id": 1188,
         "point_count": 5,
         "point_count_abbreviated": 5
-      }
+      },
+      "id": 1188
     },
     {
       "type": 1,
-      "id": 1284,
-      "geometry": [
-        [227, 121]
-      ],
+      "geometry": [[227, 121]],
       "tags": {
         "cluster": true,
-        "cluster_id": 1284,
+        "cluster_id": 1701,
         "point_count": 2,
         "point_count_abbreviated": 2
-      }
+      },
+      "id": 1701
     },
     {
       "type": 1,
-      "geometry": [
-        [210, 21]
-      ],
+      "geometry": [[210, 21]],
       "tags": {
         "scalerank": 5,
         "name": "Cape Morris Jesup",
@@ -346,36 +298,29 @@
     },
     {
       "type": 1,
-      "id": 1380,
-      "geometry": [
-        [484, 235]
-      ],
+      "geometry": [[484, 235]],
       "tags": {
         "cluster": true,
         "cluster_id": 1380,
         "point_count": 13,
         "point_count_abbreviated": 13
-      }
+      },
+      "id": 1380
     },
     {
       "type": 1,
-      "id": 1444,
-      "geometry": [
-        [503, 260]
-      ],
+      "geometry": [[503, 260]],
       "tags": {
         "cluster": true,
-        "cluster_id": 1444,
+        "cluster_id": 1925,
         "point_count": 4,
         "point_count_abbreviated": 4
-      }
+      },
+      "id": 1925
     },
     {
       "type": 1,
-      "id": 737,
-      "geometry": [
-        [502, 308]
-      ],
+      "geometry": [[502, 308]],
       "tags": {
         "scalerank": 5,
         "name": "Cape Reinga",
@@ -386,26 +331,23 @@
         "region": "Oceania",
         "subregion": "New Zealand",
         "featureclass": "cape"
-      }
+      },
+      "id": 737
     },
     {
       "type": 1,
-      "id": 1668,
-      "geometry": [
-        [475, 165]
-      ],
+      "geometry": [[475, 165]],
       "tags": {
         "cluster": true,
         "cluster_id": 1668,
         "point_count": 7,
         "point_count_abbreviated": 7
-      }
+      },
+      "id": 1668
     },
     {
       "type": 1,
-      "geometry": [
-        [511, 142]
-      ],
+      "geometry": [[511, 142]],
       "tags": {
         "scalerank": 5,
         "name": "Cape Navarin",
@@ -420,9 +362,7 @@
     },
     {
       "type": 1,
-      "geometry": [
-        [469, 106]
-      ],
+      "geometry": [[469, 106]],
       "tags": {
         "scalerank": 5,
         "name": "Cape Lopatka",
@@ -437,9 +377,7 @@
     },
     {
       "type": 1,
-      "geometry": [
-        [292, 110]
-      ],
+      "geometry": [[292, 110]],
       "tags": {
         "scalerank": 5,
         "name": "Nordkapp",
@@ -454,49 +392,40 @@
     },
     {
       "type": 1,
-      "id": 2020,
-      "geometry": [
-        [202, 262]
-      ],
+      "geometry": [[202, 262]],
       "tags": {
         "cluster": true,
-        "cluster_id": 2020,
+        "cluster_id": 4134,
         "point_count": 2,
         "point_count_abbreviated": 2
-      }
+      },
+      "id": 4134
     },
     {
       "type": 1,
-      "id": 1380,
-      "geometry": [
-        [-28, 235]
-      ],
+      "geometry": [[-28, 235]],
       "tags": {
         "cluster": true,
         "cluster_id": 1380,
         "point_count": 13,
         "point_count_abbreviated": 13
-      }
+      },
+      "id": 1380
     },
     {
       "type": 1,
-      "id": 1444,
-      "geometry": [
-        [-9, 260]
-      ],
+      "geometry": [[-9, 260]],
       "tags": {
         "cluster": true,
-        "cluster_id": 1444,
+        "cluster_id": 1925,
         "point_count": 4,
         "point_count_abbreviated": 4
-      }
+      },
+      "id": 1925
     },
     {
       "type": 1,
-      "id": 737,
-      "geometry": [
-        [-10, 308]
-      ],
+      "geometry": [[-10, 308]],
       "tags": {
         "scalerank": 5,
         "name": "Cape Reinga",
@@ -507,26 +436,23 @@
         "region": "Oceania",
         "subregion": "New Zealand",
         "featureclass": "cape"
-      }
+      },
+      "id": 737
     },
     {
       "type": 1,
-      "id": 1668,
-      "geometry": [
-        [-37, 165]
-      ],
+      "geometry": [[-37, 165]],
       "tags": {
         "cluster": true,
         "cluster_id": 1668,
         "point_count": 7,
         "point_count_abbreviated": 7
-      }
+      },
+      "id": 1668
     },
     {
       "type": 1,
-      "geometry": [
-        [-1, 142]
-      ],
+      "geometry": [[-1, 142]],
       "tags": {
         "scalerank": 5,
         "name": "Cape Navarin",
@@ -541,29 +467,25 @@
     },
     {
       "type": 1,
-      "id": 900,
-      "geometry": [
-        [539, 270]
-      ],
+      "geometry": [[539, 270]],
       "tags": {
         "cluster": true,
         "cluster_id": 900,
         "point_count": 6,
         "point_count_abbreviated": 6
-      }
+      },
+      "id": 900
     },
     {
       "type": 1,
-      "id": 996,
-      "geometry": [
-        [538, 115]
-      ],
+      "geometry": [[538, 115]],
       "tags": {
         "cluster": true,
-        "cluster_id": 996,
+        "cluster_id": 1157,
         "point_count": 2,
         "point_count_abbreviated": 2
-      }
+      },
+      "id": 1157
     }
   ]
 }

--- a/test/test.js
+++ b/test/test.js
@@ -70,9 +70,9 @@ test('returns cluster expansion zoom', (t) => {
     const index = new Supercluster().load(places.features);
     t.same(index.getClusterExpansionZoom(164), 1);
     t.same(index.getClusterExpansionZoom(196), 1);
-    t.same(index.getClusterExpansionZoom(516), 2);
-    t.same(index.getClusterExpansionZoom(996), 2);
-    t.same(index.getClusterExpansionZoom(2020), 3);
+    t.same(index.getClusterExpansionZoom(581), 2);
+    t.same(index.getClusterExpansionZoom(1157), 2);
+    t.same(index.getClusterExpansionZoom(4134), 3);
     t.end();
 });
 
@@ -83,7 +83,7 @@ test('returns cluster expansion zoom for maxZoom', (t) => {
         maxZoom: 4,
     }).load(places.features);
 
-    t.same(index.getClusterExpansionZoom(2599), 5);
+    t.same(index.getClusterExpansionZoom(2504), 5);
     t.end();
 });
 


### PR DESCRIPTION
Currently, we always create a new cluster object even if the existing cluster origin had no neighbors to merge with on lower zoom level. This is redundant for memory footprint, and also makes it impossible to identify the same cluster across multiple zooms by the same `cluster_id`. This PR fixes this by carrying cluster objects (that don't receive new points) onto lower zooms. Closes #189.