### PR TITLE
Fix longitudes outside of [-180,180] range

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,7 +387,7 @@ function getClusterProperties(cluster) {
 
 // longitude/latitude to spherical mercator in [0..1] range
 function lngX(lng) {
-    return lng / 360 + 0.5;
+    return lng / 360 + 0.5 + (lng > 180 || lng < -180 ? -Math.sign(lng) : 0);
 }
 function latY(lat) {
     const sin = Math.sin(lat * Math.PI / 180);


### PR DESCRIPTION
This is not necessarily an issue with supercluster (assuming it expects all longitudes to be within the [-180, 180] range), but it causes issues with `maplibre-gl` and `mapbox-gl`.

For example, a point with coordinates [-181, 0] renders fine in a non-cluster mode in the two mentioned libraries, but it doesn't render in a clustered geojson source.

I could fix my data before adding them to source in those libraries, but I thought if the same data works in non-clustered mode, it should work with clustered mode too and that's why I submitted the fix here.