### PR TITLE
fix: prevent crash when float  is passed as `zoom` value

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,7 +240,9 @@ export default class Supercluster {
     }
 
     _limitZoom(z) {
-        return Math.max(this.options.minZoom, Math.min(+z, this.options.maxZoom + 1));
+        return Math.floor(
+            Math.max(this.options.minZoom, Math.min(+z, this.options.maxZoom + 1))
+        );
     }
 
     _cluster(points, zoom) {

--- a/index.js
+++ b/index.js
@@ -240,9 +240,7 @@ export default class Supercluster {
     }
 
     _limitZoom(z) {
-        return Math.floor(
-            Math.max(this.options.minZoom, Math.min(+z, this.options.maxZoom + 1))
-        );
+        return Math.max(this.options.minZoom, Math.min(Math.floor(+z), this.options.maxZoom + 1));
     }
 
     _cluster(points, zoom) {

--- a/test/test.js
+++ b/test/test.js
@@ -157,6 +157,12 @@ test('does not crash on weird bbox values', (t) => {
     t.end();
 });
 
+test('does not crash on non-integer zoom values', (t) => {
+    const index = new Supercluster().load(places.features);
+    t.ok(index.getClusters([179, -10, -177, 10], 1.25));
+    t.end();
+});
+
 test('makes sure same-location points are clustered', (t) => {
     const index = new Supercluster({
         maxZoom: 20,


### PR DESCRIPTION
resolves #148 (I suspect followup comments after the original fix ran into this)

`zoom` is internally used to index into `trees`. some leaflet functions (e.g. `.flyTo()`) interpolate zoom values in which case calling methods like `.getClusters()` during interpolation causes a crash.
