### PR TITLE
Feature: get zoom level where a point gets unclustered

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ and `offset` is the amount of points to skip (for pagination).
 
 Returns the zoom on which the cluster expands into several children (useful for "click to zoom" feature) given the cluster's `cluster_id`.
 
+#### `getPointUnclusterZoom(point)`
+
+Returns the zoom on which a point appears unclustered. The point must be provided as array with `[Lng, Lat]`.
+
 ## Options
 
 | Option     | Default | Description                                                       |

--- a/index.js
+++ b/index.js
@@ -167,6 +167,27 @@ export default class Supercluster {
         return expansionZoom;
     }
 
+    getPointUnclusterZoom(point) {
+        const [lng, lat] = point;
+        const pointX = fround(lngX(lng));
+        const pointY = fround(latY(lat));
+
+        let expansionZoom = 0;
+        while (expansionZoom <= this.options.maxZoom) {
+            const tree = this.trees[expansionZoom];
+
+            const unclustered = tree.points.some(
+                treePoint => !treePoint.id && treePoint.x === pointX && treePoint.y === pointY
+            );
+
+            if (unclustered) return expansionZoom;
+
+            expansionZoom++;
+        }
+
+        return expansionZoom;
+    }
+
     _appendLeaves(result, clusterId, limit, offset, skipped) {
         const children = this.getChildren(clusterId);
 


### PR DESCRIPTION
Hello everybody,

this PR is related to the issue #193.
It adds a new function that returns the lowest zoom level, where a point isn't clustered.
