### PR TITLE
Add array type for storing coordinate values to allow improving accuracy for small radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,17 @@ Returns the zoom on which the cluster expands into several children (useful for 
 
 ## Options
 
-| Option     | Default | Description                                                       |
-|------------|---------|-------------------------------------------------------------------|
-| minZoom    | 0       | Minimum zoom level at which clusters are generated.               |
-| maxZoom    | 16      | Maximum zoom level at which clusters are generated.               |
-| minPoints  | 2       | Minimum number of points to form a cluster.                       |
-| radius     | 40      | Cluster radius, in pixels.                                        |
-| extent     | 512     | (Tiles) Tile extent. Radius is calculated relative to this value. |
-| nodeSize   | 64      | Size of the KD-tree leaf node. Affects performance.               |
-| log        | false   | Whether timing info should be logged.                             |
-| generateId | false   | Whether to generate ids for input features in vector tiles.       |
+| Option     | Default      | Description                                                                        |
+|------------|--------------|------------------------------------------------------------------------------------|
+| minZoom    | 0            | Minimum zoom level at which clusters are generated.                                |
+| maxZoom    | 16           | Maximum zoom level at which clusters are generated.                                |
+| minPoints  | 2            | Minimum number of points to form a cluster.                                        |
+| radius     | 40           | Cluster radius, in pixels.                                                         |
+| extent     | 512          | (Tiles) Tile extent. Radius is calculated relative to this value.                  |
+| nodeSize   | 64           | Size of the KD-tree leaf node. Affects performance.                                |
+| arrayType  | Float32Array | Array type to use for storing coordinate values. Affects accuracy for small radius |
+| log        | false        | Whether timing info should be logged.                                              |
+| generateId | false        | Whether to generate ids for input features in vector tiles.                        |
 
 ### Property map/reduce options
 


### PR DESCRIPTION
For small radius <~50cm, the clustering is not accurate. (Probably the accuracy will be different depending on the latitude.) The problem originates from rounding the coordinates to float32. 

# Work done
Enable arrayType argument for supercluster constructor to determine in what format store the coordinates values.
Default `Float32Array` value will work the same as before.