### PR TITLE
Fix getClusters dropping points exactly on the query bbox edge

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ export default class Supercluster {
         }
 
         const tree = this.trees[this._limitZoom(zoom)];
-        const ids = tree.range(lngX(minLng), latY(maxLat), lngX(maxLng), latY(minLat));
+        const ids = tree.range(fround(lngX(minLng)), fround(latY(maxLat)), fround(lngX(maxLng)), fround(latY(minLat)));
         const data = tree.data;
         const clusters = [];
         for (const id of ids) {

--- a/test/test.js
+++ b/test/test.js
@@ -179,3 +179,15 @@ test('does not throw on zero items', () => {
         assert.deepEqual(index.getClusters([-180, -85, 180, 85], 0), []);
     });
 });
+
+test('returns points that lie exactly on the query bbox edge', () => {
+    const index = new Supercluster().load([
+        {type: 'Feature', properties: {name: 'a'}, geometry: {type: 'Point', coordinates: [-123.211605, 43.972615]}},
+        {type: 'Feature', properties: {name: 'b'}, geometry: {type: 'Point', coordinates: [-123.245515, 43.9150233333333]}},
+        {type: 'Feature', properties: {name: 'c'}, geometry: {type: 'Point', coordinates: [-123.192528333333, 44.0307166666667]}},
+        {type: 'Feature', properties: {name: 'd'}, geometry: {type: 'Point', coordinates: [-123.194573333333, 44.0107]}}
+    ]);
+    const bbox = [-123.245515, 43.9150233333333, -123.192528333333, 44.0307166666667];
+    const names = index.getClusters(bbox, 16).map(p => p.properties.name).sort();
+    assert.deepEqual(names, ['a', 'b', 'c', 'd']);
+});


### PR DESCRIPTION
Fixes #234.

`getClusters(bbox, zoom)` silently drops a point whose longitude or latitude falls exactly on an edge of the query bbox, even though the documented bbox `[westLng, southLat, eastLng, northLat]` is inclusive.

```js
const index = new Supercluster().load(points);
// bbox computed as the exact extent of the points:
index.getClusters([minLng, minLat, maxLng, maxLat], 16);
// the point sitting on the min/max edge is missing from the result
```

This hits the common pattern of computing the bbox as the extent of the points and then querying with it, which is the scenario in #234.

## Cause

Points are stored projected and rounded to Float32 (`fround(lngX(lng))`), but the `getClusters` range query is built from full-precision Float64 bounds (`lngX(minLng)`, ...). `fround` can round a stored coordinate slightly outside its exact double, so a point that should sit on the edge ends up just beyond the inclusive `range` bound and is excluded.

## Fix

Project the query bounds through the same `fround` the stored coordinates use, so an on-edge point compares equal. `fround` is already defined in the module. The fix is scoped to `getClusters`.

## Testing

Added a test using the coordinates from #234, where the SW-corner point lies exactly on the bbox edge. On the current code that point is dropped (`['a','c','d']`); with the fix all four are returned. The rest of the suite stays green (16 tests).
