### PR TITLE
Support maxZoom >= 31 without corrupting cluster ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,9 @@ export default class Supercluster {
         this.trees = new Array(this.options.maxZoom + 1);
         this.stride = this.options.reduce ? 7 : 6;
         this.clusterProps = [];
+        // Reserve enough bits of the cluster id for the origin zoom so that a
+        // maxZoom of 31 or more does not overflow into the origin-index bits.
+        this.zoomBase = 2 ** Math.max(5, Math.ceil(Math.log2(this.options.maxZoom + 2)));
     }
 
     load(points) {
@@ -311,7 +314,7 @@ export default class Supercluster {
                 let clusterPropIndex = -1;
 
                 // encode both zoom and point index on which the cluster originated -- offset by total length of features
-                const id = ((i / stride | 0) << 5) + (zoom + 1) + this.points.length;
+                const id = (i / stride | 0) * this.zoomBase + (zoom + 1) + this.points.length;
 
                 for (const neighborId of neighborIds) {
                     const k = neighborId * stride;
@@ -358,12 +361,12 @@ export default class Supercluster {
 
     // get index of the point from which the cluster originated
     _getOriginId(clusterId) {
-        return (clusterId - this.points.length) >> 5;
+        return Math.floor((clusterId - this.points.length) / this.zoomBase);
     }
 
     // get zoom of the point from which the cluster originated
     _getOriginZoom(clusterId) {
-        return (clusterId - this.points.length) % 32;
+        return (clusterId - this.points.length) % this.zoomBase;
     }
 
     _map(data, i, clone) {

--- a/test/test.js
+++ b/test/test.js
@@ -82,6 +82,24 @@ test('returns cluster expansion zoom for maxZoom', () => {
     assert.deepEqual(index.getClusterExpansionZoom(2504), 5);
 });
 
+test('handles a maxZoom of 31 or more without corrupting cluster ids', () => {
+    const point = (lng, lat, name) => ({
+        type: 'Feature',
+        properties: {name},
+        geometry: {type: 'Point', coordinates: [lng, lat]},
+    });
+
+    for (const maxZoom of [31, 32, 40]) {
+        const index = new Supercluster({maxZoom}).load([point(10, 50, 'a'), point(10, 50, 'b')]);
+        const clusterId = index.getClusters([-180, -90, 180, 90], 0)
+            .find(f => f.properties.cluster).properties.cluster_id;
+
+        assert.deepEqual(index.getLeaves(clusterId).map(f => f.properties.name).sort(), ['a', 'b']);
+        assert.deepEqual(index.getChildren(clusterId).map(f => f.properties.name).sort(), ['a', 'b']);
+        assert.equal(index.getClusterExpansionZoom(clusterId), maxZoom + 1);
+    }
+});
+
 test('aggregates cluster properties with reduce', () => {
     const index = new Supercluster({
         map: props => ({sum: props.scalerank}),


### PR DESCRIPTION
### Problem

The cluster id packs the origin zoom into the low 5 bits:

```js
const id = ((i / stride | 0) << 5) + (zoom + 1) + this.points.length;   // encode
_getOriginId(id)   { return (id - this.points.length) >> 5; }
_getOriginZoom(id) { return (id - this.points.length) % 32; }
```

Five bits hold `zoom + 1` only up to 31, i.e. `maxZoom <= 30`. Two coincident
(or Float32-coincident) points always cluster at zoom-pass = `maxZoom`, so with
`maxZoom >= 31` the `zoom + 1` value (>= 32) overflows the zoom field into the
origin-index bits. Decoding then returns the wrong origin id/zoom, and
`getChildren` / `getLeaves` / `getClusterExpansionZoom` throw
**"No cluster with the specified id."** on input the library silently accepts —
`maxZoom` has no documented upper bound (README: default 16).

```js
const index = new Supercluster({maxZoom: 31}).load([
  {type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates: [10, 50]}},
  {type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates: [10, 50]}},
]);
const id = index.getClusters([-180, -90, 180, 90], 0).find(f => f.properties.cluster).properties.cluster_id;
index.getLeaves(id); // throws: No cluster with the specified id.
```

This is the symptom in #221 (`maxZoom: 999` → "originId is too high") and #243
("behavior strange when zoom above 20").

### Fix

Size the zoom field to the configured `maxZoom` — `zoomBase`, the smallest power
of two `>= 32` that can hold `maxZoom + 1` — and pack/unpack with `*` / `/` / `%`
instead of the fixed 5-bit shifts. `zoomBase === 32` for every `maxZoom <= 30`,
so **existing cluster ids are byte-identical** (the current tests, which assert
hardcoded ids 164/196/581/2504, still pass unchanged). Using arithmetic instead
of the 32-bit bitwise operators also removes a latent `>>` overflow for very
large point counts.

### Test

Added a case asserting `getLeaves` / `getChildren` / `getClusterExpansionZoom`
work for `maxZoom` of 31, 32 and 40. Fails on `main` ("No cluster with the
specified id."), passes with the fix; the existing 15 tests are unchanged.

Fixes #221, #243.
